### PR TITLE
qemu: add --uboot option

### DIFF
--- a/test/unit/test_argparse.py
+++ b/test/unit/test_argparse.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tuxrun.argparse import setup_parser
+from tuxrun.argparse import filter_artefacts, setup_parser
 
 
 def test_timeouts_parser():
@@ -14,3 +14,11 @@ def test_timeouts_parser():
 
     with pytest.raises(SystemExit):
         setup_parser().parse_args(["--timeouts", "booting=1"])
+
+
+def test_uboot_argument():
+    options = setup_parser().parse_args(
+        ["--device", "qemu-arm64", "--uboot", "https://example.com/u-boot.bin"]
+    )
+    assert options.uboot == "https://example.com/u-boot.bin"
+    assert filter_artefacts(options)["uboot"] == "https://example.com/u-boot.bin"

--- a/tuxrun/__main__.py
+++ b/tuxrun/__main__.py
@@ -217,6 +217,7 @@ def run(options, tmpdir: Path, cache_dir: Optional[Path], artefacts: dict) -> in
         "tmpdir": tmpdir,
         "tuxbuild": options.tuxbuild,
         "tuxmake": options.tuxmake,
+        "uboot": options.uboot,
         "uefi": options.uefi,
     }
     job = Job(**def_arguments)
@@ -297,6 +298,7 @@ def run(options, tmpdir: Path, cache_dir: Optional[Path], artefacts: dict) -> in
         job.scp_fw,
         job.scp_romfw,
         job.ssh_identity_file,
+        job.uboot,
         job.uefi,
     ] + extra_assets:
         ro = True

--- a/tuxrun/argparse.py
+++ b/tuxrun/argparse.py
@@ -47,6 +47,7 @@ def filter_artefacts(options):
         "rootfs",
         "scp-fw",
         "scp-romfw",
+        "uboot",
         "uefi",
     ]
     return {k: getattr(options, k) for k in vars(options) if k in keys}
@@ -288,6 +289,7 @@ def setup_parser() -> argparse.ArgumentParser:
         help="directory containing a TuxMake build",
     )
     artefact("test-definitions")
+    artefact("uboot")
     artefact("uefi")
     group.add_argument(
         "--fvp-ubl-license",


### PR DESCRIPTION
Forward the --uboot artefact from tuxlava.

Add the option to the argument parser, pass it to the Job, and bind-mount the file into the container so LAVA can read it. Add uboot to filter_artefacts so it is tracked with the other artefacts.