### PR TITLE
Add cca support

### DIFF
--- a/tuxrun/__main__.py
+++ b/tuxrun/__main__.py
@@ -197,6 +197,7 @@ def run(options, tmpdir: Path, cache_dir: Optional[Path], artefacts: dict) -> in
         "mcp_romfw": options.mcp_romfw,
         "modules": options.modules,
         "overlays": options.overlays,
+        "pflash": options.pflash,
         "parameters": options.parameters,
         "prompt": options.prompt,
         "qemu_image": options.qemu_image,
@@ -299,7 +300,7 @@ def run(options, tmpdir: Path, cache_dir: Optional[Path], artefacts: dict) -> in
         job.scp_romfw,
         job.ssh_identity_file,
         job.uefi,
-    ] + extra_assets:
+    ] + list(job.pflash) + extra_assets:
         ro = True
         if isinstance(path, tuple):
             path, ro = path

--- a/tuxrun/__main__.py
+++ b/tuxrun/__main__.py
@@ -187,6 +187,7 @@ def run(options, tmpdir: Path, cache_dir: Optional[Path], artefacts: dict) -> in
         "dtb": options.dtb,
         "enable_kvm": options.enable_kvm,
         "enable_trustzone": options.enable_trustzone,
+        "enable_cca": options.enable_cca,
         "enable_network": options.enable_network,
         "fip": options.fip,
         "job_definition": options.job_definition,

--- a/tuxrun/argparse.py
+++ b/tuxrun/argparse.py
@@ -382,6 +382,13 @@ def setup_parser() -> argparse.ArgumentParser:
     )
 
     group.add_argument(
+        "--enable-cca",
+        default=False,
+        action="store_true",
+        help="Enable Arm CCA (Confidential Computing Architecture) with RME support on FVP",
+    )
+
+    group.add_argument(
         "--enable-network",
         default=False,
         action="store_true",

--- a/tuxrun/argparse.py
+++ b/tuxrun/argparse.py
@@ -242,6 +242,15 @@ def setup_parser() -> argparse.ArgumentParser:
         type=int,
         help="rootfs partition number",
     )
+    group.add_argument(
+        "--pflash",
+        default=[],
+        metavar="URL",
+        type=pathurlnone,
+        help="pflash image URL. Can be specified multiple times",
+        action="append",
+        dest="pflash",
+    )
     artefact("rootfs")
     artefact("scp-fw")
     artefact("scp-romfw")
@@ -385,7 +394,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "--enable-cca",
         default=False,
         action="store_true",
-        help="Enable Arm CCA (Confidential Computing Architecture) with RME support on FVP",
+        help="Enable Arm CCA (Confidential Computing Architecture) with RME support on FVP or QEMU",
     )
 
     group.add_argument(


### PR DESCRIPTION
Add '--enable-cca' to tuxrun, the flag enables ARM CCA / RME on FVP and qemu-arm64.


Depends on tuxlava PR-20 https://github.com/kernelci/tuxlava/pull/20