### PR TITLE
runtimes: fix path translation when using --device-dict

### DIFF
--- a/tuxrun/__main__.py
+++ b/tuxrun/__main__.py
@@ -355,10 +355,12 @@ def run(options, tmpdir: Path, cache_dir: Optional[Path], artefacts: dict) -> in
     if job.device.flag_use_pre_run_cmd or job.qemu_image or options.device_dict:
         LOG.debug("Pre run command")
         if options.device_dict:
+            options.dispatcher_download_dir.mkdir(parents=True, exist_ok=True)
             runtime.bind(options.dispatcher_download_dir, Path("/srv/tftp"))
             runtime.bind(
                 options.dispatcher_download_dir, options.dispatcher_download_dir
             )
+            runtime._device_dict_volume = str(options.dispatcher_download_dir)
         else:
             runtime.bind(tmpdir / "dispatcher" / "tmp", options.dispatcher_download_dir)
             (tmpdir / "dispatcher" / "tmp").mkdir()

--- a/tuxrun/runtimes.py
+++ b/tuxrun/runtimes.py
@@ -174,13 +174,15 @@ class DockerRuntime(ContainerRuntime):
     prefix = ["docker", "run", "--rm", "--hostname", "tuxrun"]
 
     def pre_run(self, tmpdir):
-        # Render and bind the docker wrapper
+        volume = getattr(self, "_device_dict_volume", None) or str(
+            tmpdir / "dispatcher" / "tmp"
+        )
         wrap = (
             wrappers()
             .get_template("docker.jinja2")
             .render(
                 runtime="docker",
-                volume=str(tmpdir / "dispatcher" / "tmp"),
+                volume=volume,
                 dispatcher_download_dir=self.dispatcher_download_dir,
             )
         )


### PR DESCRIPTION
In device-dict mode the bind uses dispatcher_download_dir on both the host and the container. The docker wrapper rewrote mount sources to tmpdir/dispatcher/tmp instead.

This sent the wrong path to the host docker daemon. The bind failed with:

  bind source path does not exist: ...

Set _device_dict_volume to dispatcher_download_dir so the wrapper rewrite becomes a no-op in this mode.

Also create the dispatcher_download_dir on the host before binding it.