### PR TITLE
runtimes: fix path translation when using --device-dict

### DIFF
--- a/test/unit/test_runtime.py
+++ b/test/unit/test_runtime.py
@@ -118,6 +118,22 @@ def test_pre_run_docker(tmp_path):
     )
 
 
+def test_pre_run_docker_default_volume(tmp_path):
+    runtime = Runtime.select("docker")(tmp_path)
+    runtime.pre_run(tmp_path)
+    wrapper = (tmp_path / "docker").read_text(encoding="utf-8")
+    assert str(tmp_path / "dispatcher" / "tmp") in wrapper
+
+
+def test_pre_run_docker_custom_volume(tmp_path):
+    custom_volume = tmp_path / "custom" / "downloads"
+    runtime = Runtime.select("docker")(tmp_path)
+    runtime.pre_run(tmp_path, volume=custom_volume)
+    wrapper = (tmp_path / "docker").read_text(encoding="utf-8")
+    assert str(custom_volume) in wrapper
+    assert str(tmp_path / "dispatcher" / "tmp") not in wrapper
+
+
 def test_pre_run_null(tmp_path):
     runtime = Runtime.select("null")(tmp_path)
     runtime.pre_run(None)
@@ -133,6 +149,30 @@ def test_pre_run_podman(mocker, tmp_path):
     assert runtime.__pre_proc__ is not None
     popen.assert_called_once()
     run.assert_called_once()
+
+
+def test_pre_run_podman_default_volume(mocker, tmp_path):
+    (tmp_path / "podman.sock").touch()
+    mocker.patch("subprocess.Popen")
+    mocker.patch("subprocess.run")
+
+    runtime = Runtime.select("podman")(tmp_path)
+    runtime.pre_run(tmp_path)
+    wrapper = (tmp_path / "docker").read_text(encoding="utf-8")
+    assert str(tmp_path / "dispatcher" / "tmp") in wrapper
+
+
+def test_pre_run_podman_custom_volume(mocker, tmp_path):
+    (tmp_path / "podman.sock").touch()
+    mocker.patch("subprocess.Popen")
+    mocker.patch("subprocess.run")
+
+    custom_volume = tmp_path / "custom" / "downloads"
+    runtime = Runtime.select("podman")(tmp_path)
+    runtime.pre_run(tmp_path, volume=custom_volume)
+    wrapper = (tmp_path / "docker").read_text(encoding="utf-8")
+    assert str(custom_volume) in wrapper
+    assert str(tmp_path / "dispatcher" / "tmp") not in wrapper
 
 
 def test_pre_run_podman_errors(mocker, tmp_path):

--- a/tuxrun/__main__.py
+++ b/tuxrun/__main__.py
@@ -355,14 +355,17 @@ def run(options, tmpdir: Path, cache_dir: Optional[Path], artefacts: dict) -> in
     if job.device.flag_use_pre_run_cmd or job.qemu_image or options.device_dict:
         LOG.debug("Pre run command")
         if options.device_dict:
+            options.dispatcher_download_dir.mkdir(parents=True, exist_ok=True)
             runtime.bind(options.dispatcher_download_dir, Path("/srv/tftp"))
             runtime.bind(
                 options.dispatcher_download_dir, options.dispatcher_download_dir
             )
+            volume = options.dispatcher_download_dir
         else:
             runtime.bind(tmpdir / "dispatcher" / "tmp", options.dispatcher_download_dir)
             (tmpdir / "dispatcher" / "tmp").mkdir()
-        runtime.pre_run(tmpdir)
+            volume = tmpdir / "dispatcher" / "tmp"
+        runtime.pre_run(tmpdir, volume=volume)
 
     # Build the lava-run arguments list
     args = [

--- a/tuxrun/runtimes.py
+++ b/tuxrun/runtimes.py
@@ -53,7 +53,7 @@ class Runtime:
     def name(self, name):
         self.__name__ = name
 
-    def pre_run(self, tmpdir):
+    def pre_run(self, tmpdir, volume=None):
         pass
 
     def post_run(self):
@@ -111,6 +111,12 @@ class ContainerRuntime(Runtime):
     container = True
     _use_host_network = False
     _skip_http_server = False
+
+    @staticmethod
+    def _resolve_volume(tmpdir, volume):
+        if volume is None:
+            return tmpdir / "dispatcher" / "tmp"
+        return volume
 
     def __init__(self, dispatcher_download_dir):
         super().__init__(dispatcher_download_dir)
@@ -173,14 +179,14 @@ class DockerRuntime(ContainerRuntime):
     binary = "docker"
     prefix = ["docker", "run", "--rm", "--hostname", "tuxrun"]
 
-    def pre_run(self, tmpdir):
-        # Render and bind the docker wrapper
+    def pre_run(self, tmpdir, volume=None):
+        volume = self._resolve_volume(tmpdir, volume)
         wrap = (
             wrappers()
             .get_template("docker.jinja2")
             .render(
                 runtime="docker",
-                volume=str(tmpdir / "dispatcher" / "tmp"),
+                volume=str(volume),
                 dispatcher_download_dir=self.dispatcher_download_dir,
             )
         )
@@ -199,8 +205,8 @@ class PodmanRuntime(ContainerRuntime):
     prefix = ["podman", "run", "--log-driver=none", "--rm", "--hostname", "tuxrun"]
     network = None
 
-    def pre_run(self, tmpdir):
-        # Render and bind the docker wrapper
+    def pre_run(self, tmpdir, volume=None):
+        volume = self._resolve_volume(tmpdir, volume)
         self.network = os.path.basename(tmpdir)
         subprocess.run(["podman", "network", "create", self.network])
         if self.qemu_image is None:
@@ -210,7 +216,7 @@ class PodmanRuntime(ContainerRuntime):
             .get_template("docker.jinja2")
             .render(
                 runtime="podman",
-                volume=str(tmpdir / "dispatcher" / "tmp"),
+                volume=str(volume),
                 network=self.network,
                 dispatcher_download_dir=self.dispatcher_download_dir,
             )


### PR DESCRIPTION
In device-dict mode the bind uses dispatcher_download_dir on both the host and the container. The docker wrapper rewrote mount sources to tmpdir/dispatcher/tmp instead.

This sent the wrong path to the host docker daemon. The bind failed with:

  bind source path does not exist: ...

Pass the volume path explicitly to pre_run() so the caller decides which path the docker wrapper should use, based on the mode. This avoids the wrapper rewriting paths that are already host paths in device-dict mode.

Also create the dispatcher_download_dir on the host before binding it.

Reported-by: Anders Roxell <anders.roxell@linaro.org>