### PR TITLE
__main__: reformat path loop to satisfy black

### DIFF
--- a/tuxrun/__main__.py
+++ b/tuxrun/__main__.py
@@ -286,21 +286,25 @@ def run(options, tmpdir: Path, cache_dir: Optional[Path], artefacts: dict) -> in
     runtime.qemu_image = options.qemu_image
 
     runtime.bind(tmpdir)
-    for path in [
-        job.ap_romfw,
-        job.bios,
-        job.bl1,
-        job.dtb,
-        job.fip,
-        job.kernel,
-        job.mcp_fw,
-        job.mcp_romfw,
-        job.rootfs,
-        job.scp_fw,
-        job.scp_romfw,
-        job.ssh_identity_file,
-        job.uefi,
-    ] + list(job.pflash) + extra_assets:
+    for path in (
+        [
+            job.ap_romfw,
+            job.bios,
+            job.bl1,
+            job.dtb,
+            job.fip,
+            job.kernel,
+            job.mcp_fw,
+            job.mcp_romfw,
+            job.rootfs,
+            job.scp_fw,
+            job.scp_romfw,
+            job.ssh_identity_file,
+            job.uefi,
+        ]
+        + list(job.pflash)
+        + extra_assets
+    ):
         ro = True
         if isinstance(path, tuple):
             path, ro = path


### PR DESCRIPTION
The `for path in [...] + list(job.pflash) + extra_assets:` expression is too long for black's 88 column limit, so stylecheck fails.

Wrap the whole expression in parens so each `+` operand sits on its own line. No functional change.

Fixes: e8f7ae3d2b09 ("qemu: add --pflash and update --enable-cca help text")