### PR TITLE
integration: pin FVP_ARM_ARCH_VERSION for fvp-aemva

### DIFF
--- a/test/integration.py
+++ b/test/integration.py
@@ -218,6 +218,14 @@ def run(device, test, runtime, debug):
             ]
         )
 
+    elif device == "fvp-aemva":
+        args.extend(
+            [
+                "--parameters",
+                "FVP_ARM_ARCH_VERSION=9.5",
+            ]
+        )
+
     try:
         ret = subprocess.call(args)
         if ret != 0:


### PR DESCRIPTION
The new FVP model enables v9.7 CPU features by default. The kernel that the fvp-aemva rootfs ships does not support them, so it hangs before the console and auto-login times out.

Pin FVP_ARM_ARCH_VERSION to 9.5, the highest value the kernel boots with.