### PR TITLE
dispatcher: bump lava-dispatcher to 2026.05.dev0047

### DIFF
--- a/Dockerfile.tuxrun-dispatcher
+++ b/Dockerfile.tuxrun-dispatcher
@@ -1,5 +1,5 @@
 ARG LAVA_ARCH=amd64
-FROM registry.gitlab.com/lava/lava/${LAVA_ARCH}/lava-dispatcher:2026.01.dev0085
+FROM registry.gitlab.com/lava/lava/${LAVA_ARCH}/lava-dispatcher:2026.05.dev0047
 ARG HOST_ARCH=amd64
 ARG EXTRA_PACKAGES
 


### PR DESCRIPTION
The dispatcher image pinned an old lava-dispatcher 2026.01.dev0085.

Bump it to 2026.05.dev0047.