### PR TITLE
runtime: add --pull flag to refresh the dispatcher image

### DIFF
--- a/test/unit/test_runtime.py
+++ b/test/unit/test_runtime.py
@@ -267,6 +267,42 @@ def test_use_host_network(tmp_path):
     assert found_host_network, f"--network host not found in {cmd}"
 
 
+def test_pull_podman(tmp_path):
+    runtime = Runtime.select("podman")(tmp_path)
+    runtime.name("name")
+    runtime.image("image")
+    runtime.pull()
+
+    cmd = runtime.cmd(["hello", "world"])
+    assert "--pull" in cmd
+    assert cmd[cmd.index("--pull") + 1] == "newer"
+
+
+def test_pull_docker(tmp_path):
+    runtime = Runtime.select("docker")(tmp_path)
+    runtime.name("name")
+    runtime.image("image")
+    runtime.pull()
+
+    cmd = runtime.cmd(["hello", "world"])
+    assert "--pull" in cmd
+    assert cmd[cmd.index("--pull") + 1] == "always"
+
+
+def test_pull_default_off(tmp_path):
+    runtime = Runtime.select("podman")(tmp_path)
+    runtime.name("name")
+    runtime.image("image")
+
+    assert "--pull" not in runtime.cmd(["hello", "world"])
+
+
+def test_pull_null(tmp_path):
+    runtime = Runtime.select("null")(tmp_path)
+    runtime.pull()
+    assert runtime.cmd(["hello", "world"]) == ["hello", "world"]
+
+
 def test_skip_http_server_sets_entrypoint(tmp_path):
     runtime = Runtime.select("podman")(tmp_path)
     runtime.name("name")

--- a/tuxrun/__main__.py
+++ b/tuxrun/__main__.py
@@ -283,6 +283,8 @@ def run(options, tmpdir: Path, cache_dir: Optional[Path], artefacts: dict) -> in
     runtime = Runtime.select(options.runtime)(options.dispatcher_download_dir)
     runtime.name(tmpdir.name)
     runtime.image(options.image)
+    if options.pull:
+        runtime.pull()
     runtime.qemu_image = options.qemu_image
 
     runtime.bind(tmpdir)

--- a/tuxrun/argparse.py
+++ b/tuxrun/argparse.py
@@ -418,6 +418,12 @@ def setup_parser() -> argparse.ArgumentParser:
         help="Image to use",
     )
     group.add_argument(
+        "--pull",
+        default=False,
+        action="store_true",
+        help="Pull the latest image before running",
+    )
+    group.add_argument(
         "--qemu-image", default=None, help="Use qemu from the given container image"
     )
 

--- a/tuxrun/runtimes.py
+++ b/tuxrun/runtimes.py
@@ -62,6 +62,9 @@ class Runtime:
     def use_host_network(self):
         pass
 
+    def pull(self):
+        pass
+
     def cmd(self, args):
         raise NotImplementedError()  # pragma: no cover
 
@@ -111,6 +114,7 @@ class ContainerRuntime(Runtime):
     container = True
     _use_host_network = False
     _skip_http_server = False
+    _pull = False
 
     @staticmethod
     def _resolve_volume(tmpdir, volume):
@@ -137,8 +141,13 @@ class ContainerRuntime(Runtime):
     def skip_http_server(self):
         self._skip_http_server = True
 
+    def pull(self):
+        self._pull = True
+
     def cmd(self, args):
         prefix = self.prefix.copy()
+        if self._pull:
+            prefix.extend(["--pull", self.pull_policy])
         if self._use_host_network:
             prefix.extend(["--network", "host"])
         if self._skip_http_server:
@@ -178,6 +187,7 @@ class DockerRuntime(ContainerRuntime):
     bind_guestfs = False
     binary = "docker"
     prefix = ["docker", "run", "--rm", "--hostname", "tuxrun"]
+    pull_policy = "always"
 
     def pre_run(self, tmpdir, volume=None):
         volume = self._resolve_volume(tmpdir, volume)
@@ -203,6 +213,7 @@ class DockerRuntime(ContainerRuntime):
 class PodmanRuntime(ContainerRuntime):
     binary = "podman"
     prefix = ["podman", "run", "--log-driver=none", "--rm", "--hostname", "tuxrun"]
+    pull_policy = "newer"
     network = None
 
     def pre_run(self, tmpdir, volume=None):


### PR DESCRIPTION
podman and docker do not re-pull an image that already exists locally, even with the :latest tag. So a cached dispatcher image is reused and never updated.

Add a --pull flag. It maps to podman --pull=newer and docker --pull=always, so the latest image is fetched before running.

Default is off to keep normal runs fast and offline-capable.