### PR TITLE
dispatcher: bump lava-dispatcher to 2026.05.dev0091

### DIFF
--- a/Dockerfile.tuxrun-dispatcher
+++ b/Dockerfile.tuxrun-dispatcher
@@ -1,5 +1,5 @@
 ARG LAVA_ARCH=amd64
-FROM registry.gitlab.com/lava/lava/${LAVA_ARCH}/lava-dispatcher:2026.05.dev0047
+FROM registry.gitlab.com/lava/lava/${LAVA_ARCH}/lava-dispatcher:2026.05.dev0091
 ARG HOST_ARCH=amd64
 ARG EXTRA_PACKAGES
 


### PR DESCRIPTION
The dispatcher image pinned lava-dispatcher 2026.05.dev0047. This solves the missing signal we've seen on qemu-armv5.

Bump it to 2026.05.dev0091.