### PR TITLE
ci: add back python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Homepage: https://tuxrun.org/
 
 Package: tuxrun
 Architecture: all
-Depends: python3 (>= 3.11),
+Depends: python3 (>= 3.10),
          python3-requests,
          python3-jinja2,
          python3-yaml,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 ]
 readme = "README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dynamic = ["version", "description"]
 dependencies = [
     "argcomplete",

--- a/tuxrun.spec
+++ b/tuxrun.spec
@@ -30,7 +30,7 @@ Requires: tuxlava
 
 BuildArch: noarch
 
-Requires: python3 >= 3.11
+Requires: python3 >= 3.10
 
 %global debug_package %{nil}
 


### PR DESCRIPTION
Python 3.10 is not end of life yet, it goes end of life in October 2026, so keep it for now.