### PR TITLE
test: integration: arm: skip big-endian qemu devices

### DIFF
--- a/test/integration.py
+++ b/test/integration.py
@@ -283,7 +283,14 @@ def main():
             for d in Device.list(virtual_device=True)
             if fnmatch.fnmatch(d.name, pat)
         ]
-        for skip in ["fvp-lava", "qemu-lava", "qemu-riscv32", "qemu-sh4"]:
+        for skip in [
+            "fvp-lava",
+            "qemu-armv7be",
+            "qemu-arm64be",
+            "qemu-lava",
+            "qemu-riscv32",
+            "qemu-sh4",
+        ]:
             if skip in options.devices:
                 options.devices.remove(skip)
 


### PR DESCRIPTION
Big-endian arm is deprecated in the kernel and we do not test it anymore. Skip qemu-armv7be and qemu-arm64be.